### PR TITLE
fix the automatically generated title "Redirected U R L".

### DIFF
--- a/code/RedirectedURL.php
+++ b/code/RedirectedURL.php
@@ -8,6 +8,8 @@
  */
 class RedirectedURL extends DataObject {
 
+	private static $singular_name = 'Redirected URL';
+
 	private static $db = array(
 		'FromBase' => 'Varchar(255)',
 		'FromQuerystring' => 'Varchar(255)',


### PR DESCRIPTION
Silverstripe name autogenerator adds spaces in front of every capital letter.
