### PR TITLE
Update RedirectedURLHandler.php

### DIFF
--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -31,7 +31,7 @@ class RedirectedURLHandler extends Extension {
 	/**
 	 * @throws SS_HTTPResponse_Exception
 	 */
-	protected function onBeforeHTTPError404($request) {
+	public function onBeforeHTTPError404($request) {
 		$base = strtolower($request->getURL());
 
 		$getVars = $this->arrayToLowercase($request->getVars());


### PR DESCRIPTION
onBeforeHTTPError404() is not invokable by framework/core/Object.php#998 because it is protected. It must be public.
