### PR TITLE
BUG onBeforeHTTPError404 must be public to be invokable

### DIFF
--- a/code/RedirectedURLHandler.php
+++ b/code/RedirectedURLHandler.php
@@ -31,7 +31,7 @@ class RedirectedURLHandler extends Extension {
 	/**
 	 * @throws SS_HTTPResponse_Exception
 	 */
-	protected function onBeforeHTTPError404($request) {
+	public function onBeforeHTTPError404($request) {
 		$base = strtolower($request->getURL());
 
 		$getVars = $this->arrayToLowercase($request->getVars());


### PR DESCRIPTION
Fixing an error where framework/core/Object.php#998 was falling over trying to call onBeforeHTTPError404() which was protected, causing the whole module to fail.
