### PR TITLE
Fix testArrayToLowercase test case

### DIFF
--- a/tests/RedirectedURLHandlerTest.php
+++ b/tests/RedirectedURLHandlerTest.php
@@ -41,10 +41,13 @@ class RedirectedURLHandlerTest extends FunctionalTest {
 		$array = array('Foo' => 'bar', 'baz' => 'QUX');
 		
 		$cont = new RedirectedURLHandler();
+
+		$arrayToLowercaseMethod = new ReflectionMethod('RedirectedURLHandler', 'arrayToLowercase');
+		$arrayToLowercaseMethod->setAccessible(true);
 		
 		$this->assertEquals(
-			array('foo'=> 'bar', 'baz' => 'qux'), 
-			$cont->arrayToLowercase($array)
+			array('foo'=> 'bar', 'baz' => 'qux'),
+			$arrayToLowercaseMethod->invoke($cont, $array)
 		);
 	}
 }


### PR DESCRIPTION
This test was generating a fatal error as arrayToLowercase is a protected method.
