### PR TITLE
Stripping trailing slash from `To` and `FromBase`

### DIFF
--- a/code/RedirectedURL.php
+++ b/code/RedirectedURL.php
@@ -69,6 +69,7 @@ class RedirectedURL extends DataObject implements PermissionProvider {
 
 	public function setFromBase($val) {
 		if($val[0] != '/') $val = "/$val";
+		if($val != '/') $val = rtrim($val,'/');
 		$val = rtrim($val,'?');
 		$this->setField('FromBase', strtolower($val));
 	}
@@ -77,6 +78,13 @@ class RedirectedURL extends DataObject implements PermissionProvider {
 		$val = rtrim($val,'?');
 		$this->setField('FromQuerystring', strtolower($val));
 	}
+	
+	public function setTo($val) {
+		$val = rtrim($val,'?');
+		if($val != '/') $val = rtrim($val,'/');
+		$this->setField('To', strtolower($val));
+	}
+
 
 	/**
 	 * Helper for bulkloader {@link: RedirectedURLAdmin.getModelImporters}


### PR DESCRIPTION
The check within `RedirectedURLHandler` [assumes no trailing slash](https://github.com/silverstripe-labs/silverstripe-redirectedurls/blob/master/code/RedirectedURLHandler.php#L41), this changes ensures there are no trailing slashes.

This tripped me up when I first used the plugin, it would be nice to remove this potential stumbling block.